### PR TITLE
Use swiftenv to install swift version on macOS CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,12 @@ jobs:
     runs-on: macos-latest
     needs: create_release
     steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
-        with:
-          xcode-version: latest
+      - name: Install swiftenv
+        run: brew install kylef/formulae/swiftenv
       - uses: actions/checkout@v2
+      - name: Install swift version
+        # If already installed, will fail
+        run: swiftenv install || true && if which swiftenv > /dev/null; then eval "$(swiftenv init -)"; fi 
       - name: Build
         run: swift build -c release
       - name: Package
@@ -98,7 +99,7 @@ jobs:
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: changes.tar.gz
-          asset_name: changes-swift-5-3-macOS-dynamic.tar.gz
+          asset_name: changes-swift-5-3-1-macOS-dynamic.tar.gz
           asset_content_type: application/gzip
 
 


### PR DESCRIPTION
I changed this to use swiftenv on macOS. This is mainly so I don't have to pay attention to what Xcode versions are installed on Github CI. 

Right now, I still have to change the docker image name when I updated swift versions. Maybe I can automate that later at some point as well. 